### PR TITLE
Fix terminal command & add link to pytest docs

### DIFF
--- a/permute_general.py
+++ b/permute_general.py
@@ -14,7 +14,9 @@ When you want to move onto the more advanced tests:
 
 Or - if you are brave, from the terminal command line:
 
-    pytest permute_general
+    pytest permute_general.py
+
+See the guide for installing and getting started with pytest: https://docs.pytest.org/en/7.4.x/getting-started.html
 """
 
 import numpy as np


### PR DESCRIPTION
Running `pytest permute_general` in the command line will give the error "file or directory not found: permute_general" - the file extension needs to be specified.

I also found I did not have `pytest` installed, I've added a link to the getting started page in the docs which might be helpful for others.